### PR TITLE
Checksum download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check-prereqs:
 	@command -v docsible >/dev/null 2>&1 || { echo "❌ 'docsible' not found in PATH. Please install it."; exit 1; }
 	@echo "✅ All prerequisites found."
 
-all:git-clean lint test docs git-clean
+all: lint test docs git-clean
 
 test: test-os test-scenarios
 

--- a/README.md
+++ b/README.md
@@ -26,31 +26,29 @@ Description: Ansible role to install and manage opkssh, a tool that enables SSH 
 
 | Var          | Type         | Value       |Required    | Title       |
 |--------------|--------------|-------------|------------|-------------|
-| [opkssh_version](defaults/main.yml#L4)   | str | `v0.7.0` |    True  |  Version of opkssh to install |
-| [opkssh_bin_checksum](defaults/main.yml#L9)   | str | `sha256:047ce46214e94c25820a3345927886c048a93254af329e50fa5e76cc43269556` |    True  |  Checksum of opkssh to install |
-| [opkssh_user](defaults/main.yml#L14)   | str | `opksshuser` |    True  |  Username uses for execution of opkssh |
-| [opkssh_group](defaults/main.yml#L19)   | str | `opksshuser` |    True  |  Default group for opkssh user |
-| [opkssh_selinux_home](defaults/main.yml#L23)   | bool | `True` |    True  |  Boolean to set wether to use the home directory policy feature |
-| [opkssh_restart_ssh](defaults/main.yml#L27)   | bool | `True` |    True  |  Boolean to set if openSSH server should be restarted or not |
-| [opkssh_install_path](defaults/main.yml#L31)   | str | `/usr/local/bin` |    True  |  Path to where opkssh binary should be installed |
-| [opkssh_binary_name](defaults/main.yml#L35)   | str | `opkssh` |    True  |  Name of the opkssh binary |
-| [opkssh_github_repo](defaults/main.yml#L39)   | str | `openpubkey/opkssh` |    True  |  GitHub repository to download the opkssh binary from |
-| [opkssh_sudoers_path](defaults/main.yml#L43)   | str | `/etc/sudoers.d` |    True  |  Path to the sudoers file for opkssh |
-| [opkssh_ssh_config_filename](defaults/main.yml#L47)   | str | `60-opk-ssh.conf` |    True  |  Name of the opkssh openSSH config file |
-| [opkssh_config_yml](defaults/main.yml#L52)   | dict | `{}` |    True  |  Content of /etc/opk/config.yml |
-| [opkssh_auth_id](defaults/main.yml#L57)   | list | `[]` |    True  |  Content of /etc/opk/auth_id file |
-| [opkssh_providers](defaults/main.yml#L62)   | list | `[]` |    True  |  Content of /etc/opk/providers |
-| [opkssh_providers.**0**](defaults/main.yml#L63)   | str | `https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h` |    None  |  None |
-| [opkssh_providers.**1**](defaults/main.yml#L64)   | str | `https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h` |    None  |  None |
-| [opkssh_providers.**2**](defaults/main.yml#L65)   | str | `https://gitlab.com 8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923 24h` |    None  |  None |
-| [opkssh_providers.**3**](defaults/main.yml#L66)   | str | `https://issuer.hello.coop app_xejobTKEsDNSRd5vofKB2iay_2rN 24h` |    None  |  None |
+| [opkssh_version](defaults/main.yml#L4)   | str | `latest` |    True  |  Version of opkssh to install |
+| [opkssh_user](defaults/main.yml#L9)   | str | `opksshuser` |    True  |  Username uses for execution of opkssh |
+| [opkssh_group](defaults/main.yml#L14)   | str | `opksshuser` |    True  |  Default group for opkssh user |
+| [opkssh_selinux_home](defaults/main.yml#L18)   | bool | `True` |    True  |  Boolean to set wether to use the home directory policy feature |
+| [opkssh_restart_ssh](defaults/main.yml#L22)   | bool | `True` |    True  |  Boolean to set if openSSH server should be restarted or not |
+| [opkssh_install_path](defaults/main.yml#L26)   | str | `/usr/local/bin` |    True  |  Path to where opkssh binary should be installed |
+| [opkssh_binary_name](defaults/main.yml#L30)   | str | `opkssh` |    True  |  Name of the opkssh binary |
+| [opkssh_github_repo](defaults/main.yml#L34)   | str | `openpubkey/opkssh` |    True  |  GitHub repository to download the opkssh binary from |
+| [opkssh_sudoers_path](defaults/main.yml#L38)   | str | `/etc/sudoers.d` |    True  |  Path to the sudoers file for opkssh |
+| [opkssh_ssh_config_filename](defaults/main.yml#L42)   | str | `60-opk-ssh.conf` |    True  |  Name of the opkssh openSSH config file |
+| [opkssh_config_yml](defaults/main.yml#L47)   | dict | `{}` |    True  |  Content of /etc/opk/config.yml |
+| [opkssh_auth_id](defaults/main.yml#L52)   | list | `[]` |    True  |  Content of /etc/opk/auth_id file |
+| [opkssh_providers](defaults/main.yml#L57)   | list | `[]` |    True  |  Content of /etc/opk/providers |
+| [opkssh_providers.**0**](defaults/main.yml#L58)   | str | `https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h` |    None  |  None |
+| [opkssh_providers.**1**](defaults/main.yml#L59)   | str | `https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h` |    None  |  None |
+| [opkssh_providers.**2**](defaults/main.yml#L60)   | str | `https://gitlab.com 8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923 24h` |    None  |  None |
+| [opkssh_providers.**3**](defaults/main.yml#L61)   | str | `https://issuer.hello.coop app_xejobTKEsDNSRd5vofKB2iay_2rN 24h` |    None  |  None |
 <details>
 <summary><b>🖇️ Full descriptions for vars in defaults/main.yml</b></summary>
 <br>
 <table>
 <th>Var</th><th>Description</th>
-<tr><td><b>opkssh_version</b></td><td>The version of opkssh to install, if 'latest' is used the role can break idempotency</td></tr>
-<tr><td><b>opkssh_bin_checksum</b></td><td>The sha256 checksum of the opkssh binary, not used if opkss_version is set to 'latest'</td></tr>
+<tr><td><b>opkssh_version</b></td><td>The version of opkssh to install, latest or vX.Y.Z</td></tr>
 <tr><td><b>opkssh_user</b></td><td>The system user responsible for executing the AuthorizedKeysCommand</td></tr>
 <tr><td><b>opkssh_group</b></td><td>Group ownership for installed files and directories</td></tr>
 <tr><td><b>opkssh_config_yml</b></td><td>Content must be valid YAML format</td></tr>
@@ -87,7 +85,8 @@ Description: Ansible role to install and manage opkssh, a tool that enables SSH 
 | Print out the SELinux status | ansible.builtin.debug | True |
 | Set the correct name for opkssh SELinux module | ansible.builtin.set_fact | False |
 | Check if SELinux module is installed and run handlers | ansible.builtin.command | True |
-| Create opkssh configuration directory | ansible.builtin.file | False |
+| Remove opkssh configuration directory | ansible.builtin.file | False |
+| Remove opkssh SELinux source directory | ansible.builtin.file | False |
 | Configure openSSH Server | ansible.builtin.file | False |
 | Add sudoers file for opkssh | ansible.builtin.file | True |
 
@@ -97,8 +96,11 @@ Description: Ansible role to install and manage opkssh, a tool that enables SSH 
 | ---- | ------ | -------------- |
 | Set binary name based on architecture | ansible.builtin.set_fact | False |
 | Fail if unsupported architecture | ansible.builtin.fail | True |
-| Download opkssh (latest) | ansible.builtin.get_url | True |
-| Download opkssh specific version: {{ opkssh_version }} | ansible.builtin.get_url | True |
+| Set opkssh download base URL | ansible.builtin.set_fact | False |
+| Download checksum list | ansible.builtin.uri | False |
+| Find the checksums line for opkssh binary | ansible.builtin.set_fact | False |
+| Extract SHA256 hash from the matched checksum line | ansible.builtin.set_fact | False |
+| Download opkssh {{ opkssh_version }} | ansible.builtin.get_url | False |
 
 #### File: tasks/main.yml
 
@@ -151,7 +153,7 @@ No dependencies specified.
 
 ### Example Playbooks
 
-#### Install opkssh with the opkssh role default version
+#### Install opkssh with the opkssh role default role version (latest)
 ```yaml
 - hosts: all
   roles:
@@ -166,7 +168,6 @@ No dependencies specified.
     - role: opkssh
       vars:
         opkssh_version: v0.6.1
-        opkssh_bin_checksum: "sha256:61646ef0f977aaa374a31e3135d322b8b29c86d51695eb02642e9e0166ef15dd"
 ```
 
 #### Install opkssh latest version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,7 @@
 # title: Version of opkssh to install
 # required: True
-# description: The version of opkssh to install, if 'latest' is used the role can break idempotency
-opkssh_version: v0.7.0
-
-# title: Checksum of opkssh to install
-# required: True
-# description: The sha256 checksum of the opkssh binary, not used if opkss_version is set to 'latest'
-opkssh_bin_checksum: sha256:047ce46214e94c25820a3345927886c048a93254af329e50fa5e76cc43269556
+# description: The version of opkssh to install, latest or vX.Y.Z
+opkssh_version: latest
 
 # title: Username uses for execution of opkssh
 # required: True

--- a/molecule/absent-selinux/verify.yml
+++ b/molecule/absent-selinux/verify.yml
@@ -86,6 +86,18 @@
         fail_msg: "/etc/opk directory still exists"
         success_msg: "/etc/opk directory has been removed"
 
+    - name: Assert opkssh SELinux source directory does NOT exist
+      ansible.builtin.stat:
+        path: /usr/share/opkssh
+      register: opksshselinux_dir_info
+
+    - name: Verify /etc/opk directory was removed
+      ansible.builtin.assert:
+        that:
+          - not opksshselinux_dir_info.stat.exists
+        fail_msg: "/etc/share/opkssh directory still exists"
+        success_msg: "/etc/share/opkssh directory has been removed"
+
     - name: Check if opkssh SELinux module is still installed
       ansible.builtin.command:
         cmd: semodule -l

--- a/molecule/absent-selinux/verify.yml
+++ b/molecule/absent-selinux/verify.yml
@@ -91,12 +91,12 @@
         path: /usr/share/opkssh
       register: opksshselinux_dir_info
 
-    - name: Verify /etc/opk directory was removed
+    - name: Verify /usr/share/opkssh directory was removed
       ansible.builtin.assert:
         that:
           - not opksshselinux_dir_info.stat.exists
-        fail_msg: "/etc/share/opkssh directory still exists"
-        success_msg: "/etc/share/opkssh directory has been removed"
+        fail_msg: "/usr/share/opkssh directory still exists"
+        success_msg: "/usr/share/opkssh directory has been removed"
 
     - name: Check if opkssh SELinux module is still installed
       ansible.builtin.command:

--- a/molecule/variables/vars.yml
+++ b/molecule/variables/vars.yml
@@ -1,6 +1,5 @@
 ---
 opkssh_version: v0.6.1
-opkssh_bin_checksum: "sha256:61646ef0f977aaa374a31e3135d322b8b29c86d51695eb02642e9e0166ef15dd"
 opkssh_user: foo
 opkssh_group: bar
 opkssh_install_path: /usr/bin

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -32,9 +32,14 @@
     - ansible_selinux is defined
     - ansible_selinux.status not in ['disabled', 'Missing selinux Python library']
 
-- name: Create opkssh configuration directory
+- name: Remove opkssh configuration directory
   ansible.builtin.file:
     path: /etc/opk
+    state: absent
+
+- name: Remove opkssh SELinux source directory
+  ansible.builtin.file:
+    path: /usr/share/opkssh
     state: absent
 
 - name: Configure openSSH Server

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -12,24 +12,38 @@
     msg: "Unsupported architecture: {{ ansible_architecture }}"
   when: opkssh_binary_arch == 'unsupported'
 
-- name: Download opkssh (latest)
-  ansible.builtin.get_url:
-    url: "https://github.com/{{ opkssh_github_repo }}/releases/latest/download/opkssh-linux-{{ opkssh_binary_arch }}"
-    dest: "{{ opkssh_install_path }}/{{ opkssh_binary_name }}"
-    owner: root
-    group: root
-    mode: "0755"
-    force: true
-  when: opkssh_version == "latest"
-  notify: Restore SELinux context for opkssh
+- name: Set opkssh download base URL
+  ansible.builtin.set_fact:
+    opkssh_download_base_url: >-
+      https://github.com/{{ opkssh_github_repo }}/releases{{ '/latest/download/' if opkssh_version == 'latest' else '/download/' ~ opkssh_version ~ '/' }}
 
-- name: "Download opkssh specific version: {{ opkssh_version }}"
+- name: Download checksum list
+  ansible.builtin.uri:
+    url: "{{ opkssh_download_base_url }}checksums.txt"
+    return_content: true
+  register: checksums_txt
+
+- name: Find the checksums line for opkssh binary
+  ansible.builtin.set_fact:
+    opkssh_checksum_line: >-
+      {{
+        checksums_txt.content.splitlines()
+        | select('search', "opkssh-linux-" ~ opkssh_binary_arch)
+        | list
+        | default([])
+        | first | default('')
+      }}
+
+- name: Extract SHA256 hash from the matched checksum line
+  ansible.builtin.set_fact:
+    opkssh_sha256: "{{ opkssh_checksum_line | regex_search('^([0-9a-f]{64})', '\\1') }}"
+
+- name: "Download opkssh {{ opkssh_version }}"
   ansible.builtin.get_url:
-    url: "https://github.com/{{ opkssh_github_repo }}/releases/download/{{ opkssh_version }}/opkssh-linux-{{ opkssh_binary_arch }}"
+    url: "{{ opkssh_download_base_url }}opkssh-linux-{{ opkssh_binary_arch }}"
     dest: "{{ opkssh_install_path }}/{{ opkssh_binary_name }}"
     owner: root
     group: root
     mode: "0755"
-    checksum: "{{ opkssh_bin_checksum }}"
-  when: opkssh_version != "latest"
+    checksum: "sha256:{{ opkssh_sha256 }}"
   notify: Restore SELinux context for opkssh


### PR DESCRIPTION
Download checksum from repository instead of hardcode it.
This makes tag `latest` idempotent and it makes it easier to
select version if the checksum variable isn't mandatory.

Also fixes the missed removal of /usr/share/opkssh in absent tasks
and adds verification of the removal added in https://github.com/SweBarre/opkssh-role/commit/ab2eab62ea11921d0c4eba960a4631241954b08f

```
[ci.yaml/Lint with Ansible Lint] 🏁  Job succeeded
Running molecule test for each MOLECULE_TAG...
💡 Use TAG to select what to run; make test-os TAGS="debian-12 arch tumbleweed"
==> opensuse-15.6   ✅ PASS (2m7s)
==> debian-12       ✅ PASS (1m42s)
==> debian-sid      ✅ PASS (1m48s)
==> arch            ✅ PASS (1m49s)
==> ubuntu-22.04    ✅ PASS (1m51s)
==> ubuntu-24.04    ✅ PASS (1m56s)
==> rockylinux-9    ✅ PASS (1m33s)
==> tumbleweed      ✅ PASS (1m49s)

============================
Tag Summary: 8 of 8 passed
             0 of 8 failed
============================
Running all Molecule scenarios...
==> aarch64         ✅ PASS (6m19s)
==> absent          ✅ PASS (1m30s)
==> absent-selinux  ✅ PASS (1m38s)
==> default         ✅ PASS (1m46s)
==> selinux         ✅ PASS (1m45s)
==> selinux-no-home ✅ PASS (1m39s)
==> variables       ✅ PASS (1m46s)

============================
Summary: 7 of 7 passed
         0 of 7 failed
============================
```