### PR TITLE
Make read-only uri tasks check_mode-safe so --check works

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -22,6 +22,10 @@
     url: "{{ opkssh_download_base_url }}checksums.txt"
     return_content: true
   register: checksums_txt
+  # Read-only request; must run under --check so the computed sha256 is
+  # available to the get_url checksum below (otherwise it is empty and
+  # get_url fails with "The checksum format is invalid").
+  check_mode: false
 
 - name: Find the checksums line for opkssh binary
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,9 @@
     return_content: true
   register: release_info
   when: opkssh_version == "latest"
+  # Read-only request; must run under --check so version_installed resolves
+  # when opkssh_version is 'latest' (otherwise the next set_fact fails).
+  check_mode: false
 
 - name: Set opkssh version installed
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem

Running a playbook that uses this role with `--check` fails at the binary download:

```
TASK [opkssh : Download opkssh v0.15.0]
[ERROR]: Module failed: The checksum format is invalid
... "checksum": "sha256:", "msg": "The checksum format is invalid" ...
```

Real (non-check) runs work fine.

## Cause

Ansible's `uri` module is **skipped under `--check`** (it is read-only, but check mode still skips it). The role relies on two `uri` tasks:

- `tasks/client.yml` → *Download checksum list* (`checksums.txt`)
- `tasks/main.yml` → *Get latest release info from GitHub API* (only when `opkssh_version: latest`)

When skipped, `checksums_txt.content` is unset, so `opkssh_sha256` resolves to an empty string and `get_url` receives `checksum: "sha256:"` → *"The checksum format is invalid"*. With `opkssh_version: latest`, `version_installed` likewise fails to resolve.

## Fix

Mark both read-only GET requests `check_mode: false` so they execute during `--check`, letting the computed checksum / version be available to the downstream tasks. No behavior change outside check mode.

## Testing

- `--check` against an Ubuntu 24.04 host with `opkssh_version: v0.15.0`: previously failed with the checksum error, now completes.
- Normal apply: unchanged (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
