### PR TITLE
Access facts via ansible_facts namespace (fix INJECT_FACTS_AS_VARS deprecation)

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,8 +8,8 @@
 - name: Restore SELinux context for opkssh
   ansible.builtin.command: "restorecon {{ opkssh_install_path }}/{{ opkssh_binary_name }}"
   when:
-    - ansible_selinux is defined
-    - ansible_selinux.status not in ['disabled', 'Missing selinux Python library']
+    - ansible_facts['selinux'] is defined
+    - ansible_facts['selinux'].status not in ['disabled', 'Missing selinux Python library']
   changed_when: true
 
 - name: Compile SELinux module

--- a/tasks/absent.yml
+++ b/tasks/absent.yml
@@ -16,8 +16,8 @@
 
 - name: Print out the SELinux status
   ansible.builtin.debug:
-    msg: "SELinux status is: {{ ansible_selinux }}"
-  when: ansible_selinux is defined
+    msg: "SELinux status is: {{ ansible_facts['selinux'] }}"
+  when: ansible_facts['selinux'] is defined
 
 - name: Set the correct name for opkssh SELinux module
   ansible.builtin.set_fact:
@@ -29,8 +29,8 @@
   changed_when: semodule_name in semodule_list.stdout
   notify: Remove SELinux module
   when:
-    - ansible_selinux is defined
-    - ansible_selinux.status not in ['disabled', 'Missing selinux Python library']
+    - ansible_facts['selinux'] is defined
+    - ansible_facts['selinux'].status not in ['disabled', 'Missing selinux Python library']
 
 - name: Remove opkssh configuration directory
   ansible.builtin.file:

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -2,14 +2,14 @@
   ansible.builtin.set_fact:
     opkssh_binary_arch: >-
       {{
-        'amd64' if ansible_architecture == 'x86_64'
-        else 'arm64' if ansible_architecture == 'aarch64'
+        'amd64' if ansible_facts['architecture'] == 'x86_64'
+        else 'arm64' if ansible_facts['architecture'] == 'aarch64'
         else 'unsupported'
       }}
 
 - name: Fail if unsupported architecture
   ansible.builtin.fail:
-    msg: "Unsupported architecture: {{ ansible_architecture }}"
+    msg: "Unsupported architecture: {{ ansible_facts['architecture'] }}"
   when: opkssh_binary_arch == 'unsupported'
 
 - name: Set opkssh download base URL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,8 +40,8 @@
   ansible.builtin.include_tasks:
     file: selinux.yml
   when:
-    - ansible_selinux is defined
-    - ansible_selinux.status not in ['disabled', 'Missing selinux Python library']
+    - ansible_facts['selinux'] is defined
+    - ansible_facts['selinux'].status not in ['disabled', 'Missing selinux Python library']
 
 - name: Create opkssh configuration directory
   ansible.builtin.file:


### PR DESCRIPTION
## Problem

Running this role emits deprecation warnings:

```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated,
top-level facts will not be auto injected after the change. This feature will
be removed from ansible-core version 2.24.
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```

The role reads facts via the legacy top-level variables `ansible_architecture`
and `ansible_selinux`, which are injected only while `INJECT_FACTS_AS_VARS` is
true. Once that defaults to `false` (ansible-core 2.24) these references stop
resolving and the role breaks (e.g. SELinux gating, arch detection).

## Fix

Access the same facts through the `ansible_facts.*` namespace, which is always
available regardless of `INJECT_FACTS_AS_VARS`:

- `ansible_architecture` → `ansible_facts['architecture']` (tasks/client.yml)
- `ansible_selinux`       → `ansible_facts['selinux']`     (tasks/main.yml, tasks/absent.yml, handlers/main.yml)

`vars/main.yml` already used `ansible_facts['os_family']`, so this brings the
rest of the role in line. No behavior change — purely the access path.

## Testing

- `ansible-playbook --syntax-check` passes.
- Applied on Ubuntu 24.04 (non-SELinux): the `ansible_facts['selinux'] is defined`
  guards behave identically; no deprecation warnings from the role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
